### PR TITLE
Fix NullpointerException in getGlobalRating

### DIFF
--- a/src/main/java/database/DatabaseManager.java
+++ b/src/main/java/database/DatabaseManager.java
@@ -525,6 +525,12 @@ public class DatabaseManager {
     }
 
     protected RatingInfo _getGlobalRating(MainMeal meal) {
+
+        // Cannot return global rating for meals which are still waiting for admin input
+        if (meal.getId() == null) {
+            return null;
+        }
+
         try {
             LOAD_GLOBAL_RATING.clearParameters();
             LOAD_GLOBAL_RATING.setInt(1, meal.getId());


### PR DESCRIPTION
Added a check that catches the case in which the admins did not answer the poll fast enough.
Now, the meal will just say “Not rated” for meals waiting for an answer. 